### PR TITLE
shortcode for github file codeblock

### DIFF
--- a/content/en/docs/Reference/codeblock.md
+++ b/content/en/docs/Reference/codeblock.md
@@ -1,0 +1,10 @@
+---
+title: "Codeblock from GitHub URL"
+linkTitle: "Codeblock from GitHub URL"
+date: 2023-06-24
+weight: 6
+description: Adding a codeblock from GitHub URL
+---
+
+{{< ghcode "https://raw.githubusercontent.com/ClickHouse/clickhouse-go/main/tests/array_test.go" >}}
+

--- a/layouts/shortcodes/ghcode.html
+++ b/layouts/shortcodes/ghcode.html
@@ -1,0 +1,12 @@
+{{ $u := .Get 0 }}
+{{ with resources.GetRemote $u }}
+  {{ with .Err }}
+    {{ errorf "%s" . }}
+  {{ else }}
+    {{ $lang := path.Ext $u | strings.TrimPrefix "." }}
+    {{ highlight .Content $lang }}
+  {{ end }}
+{{ else }}
+  {{ errorf "Unable to get remote resource." }}
+{{ end }}
+


### PR DESCRIPTION
From https://discourse.gohugo.io/t/is-there-a-way-to-embed-raw-github-url-in-hugo/39957/6